### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "Bot"

--- a/.github/workflows/gha_generate_readme_and_issuetemp.yml
+++ b/.github/workflows/gha_generate_readme_and_issuetemp.yml
@@ -32,6 +32,7 @@ jobs:
           && python generate_issue_template.py
 
       - name: Check Links
+        shell: bash -l {0}
         run:  python -m pytest --check-links
 
       - name: Commit and push if it changed


### PR DESCRIPTION
Added dependabot to help keep the GitHub actions updated and fixed a mistake in #49 that prevented it from running. 