### PR TITLE
Run GHA on every PR.

### DIFF
--- a/.github/workflows/gha_generate_readme_and_issuetemp.yml
+++ b/.github/workflows/gha_generate_readme_and_issuetemp.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Check Links
         shell: bash -l {0}
-        run:  python -m pytest --check-links
+        run:  pytest --verbose --check-links README.md
 
       - name: Commit and push if it changed
         if: success() && github.ref == 'refs/heads/main'

--- a/.github/workflows/gha_generate_readme_and_issuetemp.yml
+++ b/.github/workflows/gha_generate_readme_and_issuetemp.yml
@@ -1,6 +1,7 @@
 name: Generate README and ISSUE TEMPLATE workflow
 
 on:
+  pull_request:
   push:
      branches:
        - main
@@ -36,6 +37,7 @@ jobs:
         run:  python -m pytest --check-links
 
       - name: Commit and push if it changed
+        if: success() && github.ref == 'refs/heads/main'
         shell: bash -l {0}
         run: >
           git config user.name "GitHub Action"


### PR DESCRIPTION
Note that we do not want to commit on PRs though. We are commiting on every merge to main. However, I would change that to every release if controlling the final markdown file with releases make sense. There is an extra maintenance burden if we go the release route.