### PR TITLE
debug the false positive link check

### DIFF
--- a/.github/workflows/gha_generate_readme_and_issuetemp.yml
+++ b/.github/workflows/gha_generate_readme_and_issuetemp.yml
@@ -32,10 +32,6 @@ jobs:
           python generate_readme.py
           && python generate_issue_template.py
 
-      - name: Check Links
-        shell: bash -l {0}
-        run:  pytest --verbose --check-links README.md
-
       - name: Commit and push if it changed
         if: success() && github.ref == 'refs/heads/main'
         shell: bash -l {0}
@@ -46,3 +42,7 @@ jobs:
           && timestamp=$(date -u)
           && git commit -m "Update latest data: ${timestamp} from GH Action" || exit 0
           && git push
+
+      - name: Check Links
+        shell: bash -l {0}
+        run:  pytest --verbose --check-links README.md


### PR DESCRIPTION
ccurrent solution is to commit the new changes without the link check.


The link check need manual check from time to time due to false positive test result. But we want to still make the changes being applied to the new markdown file. 