### PR TITLE
seperate link check to daily routine

### DIFF
--- a/.github/workflows/gha_check_link_daily.yml
+++ b/.github/workflows/gha_check_link_daily.yml
@@ -1,0 +1,23 @@
+name: Run Pytest Daily on Main
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Micromamba ${{ matrix.python-version }}
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
+          init-shell: bash
+
+      - name: link check
+        shell: bash -l {0}
+        run: pytest --verbose --check-links README.md

--- a/.github/workflows/gha_generate_readme_and_issuetemp.yml
+++ b/.github/workflows/gha_generate_readme_and_issuetemp.yml
@@ -42,7 +42,3 @@ jobs:
           && timestamp=$(date -u)
           && git commit -m "Update latest data: ${timestamp} from GH Action" || exit 0
           && git push
-
-      - name: Check Links
-        shell: bash -l {0}
-        run:  pytest --verbose --check-links README.md


### PR DESCRIPTION
The GHA is updated with automatic link check perform separately daily at 12pm. This will avoid the unnecessary slow down of link check at every PR. The inidividual link check is also done in every PR created from issue when there is a new resource contribution.