### PR TITLE
reorganize GHA order and trigger file

### DIFF
--- a/.github/ISSUE_TEMPLATE/header_file/add_cefi_resource_head.yml
+++ b/.github/ISSUE_TEMPLATE/header_file/add_cefi_resource_head.yml
@@ -1,7 +1,6 @@
 name: header file
 description: The form is designed for user to easily contribute to the CEFI resource list that will be used in the CEFI resource search portal
 title: "[Add new CEFI resource]: "
-labels: ["new resource"]
 assignees:
   - chiaweh2
 body:

--- a/.github/workflows/gha_generate_pr.yml
+++ b/.github/workflows/gha_generate_pr.yml
@@ -1,10 +1,12 @@
 name: Modify JSON and Create Pull Request
 on:
   issues:
-    types: [opened, labeled]
+    types: 
+      - labeled
 
 jobs:
   auto_new_resource_add_pr:
+    if: contains(github.event.issue.labels.*.name, 'new resource')
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repository
@@ -17,7 +19,6 @@ jobs:
           init-shell: bash
 
       - name: Parsing issue, download figure, and modify json
-        if: contains(github.event.issue.labels.*.name, 'new resource')
         shell: bash -l {0}
         run: python generate_pr_from_issue.py
 
@@ -27,10 +28,9 @@ jobs:
 
       - name: include new resource in README
         shell: bash -l {0}
-        run: python generate_readme.py  
+        run: python generate_readme.py
 
       - name: Create Pull Request
-        if: contains(github.event.issue.labels.*.name, 'new resource')
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gha_generate_readme_and_issuetemp.yml
+++ b/.github/workflows/gha_generate_readme_and_issuetemp.yml
@@ -7,6 +7,7 @@ on:
        - main
      paths:
        - 'generate_issue_template.py' 
+       - '.github/ISSUE_TEMPLATE/header_file/add_cefi_resource_head.yml'
        - 'generate_readme.py'
        - 'data/cefi_list.json'
 #  schedule:


### PR DESCRIPTION
The PR creation is only trigger when labeling a issue
The default of issue will be no label
The trigger of issue template generation is also triggered when the header file is changed