### PR TITLE
adding new link that keep having fails check 

### DIFF
--- a/daily_linkcheck.py
+++ b/daily_linkcheck.py
@@ -51,7 +51,8 @@ if __name__=="__main__":
     ex_list = [
         # "https://www.epa.gov/climate-indicators",
         # "https://climatereanalyzer.org/",
-        "https://nodc.id/oceanography"
+        "https://nodc.id/oceanography",
+        "https://oceanadapt.rutgers.edu",
     ]
 
     # Provide the path to your text file


### PR DESCRIPTION
the link is skipped from the link check. Need to check in manually for the excluded links. 

Current:
        "https://nodc.id/oceanography",
        "https://oceanadapt.rutgers.edu",